### PR TITLE
Add float to string decoding option

### DIFF
--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -87,6 +87,12 @@ defmodule Jason.Decoder do
     end
   end
 
+  defp float_decode_function(%{floats: :strings}) do
+    fn string, _token, _skip ->
+      string
+    end
+  end
+
   defp value(data, original, skip, stack, key_decode, string_decode, float_decode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -122,6 +122,18 @@ defmodule Jason.DecodeTest do
              Decimal.new("123456789.123456789e123")
   end
 
+  test "parsing floats to strings" do
+    assert parse!("0.1", floats: :strings) == "0.1"
+    assert parse!("-0.1", floats: :strings) == "-0.1"
+    assert parse!("1.0e0", floats: :strings) == "1.0e0"
+    assert parse!("1.0e+0", floats: :strings) == "1.0e+0"
+    assert parse!("0.1e1", floats: :strings) == "0.1e1"
+    assert parse!("0.1e-1", floats: :strings) == "0.1e-1"
+
+    assert parse!("123456789.123456789e123", floats: :strings) ==
+             "123456789.123456789e123"
+  end
+
   test "arrays" do
     assert_fail_with "[", "unexpected end of input at position 1"
     assert_fail_with "[,", "unexpected byte at position 1: 0x2C (',')"


### PR DESCRIPTION
Hi,

This is a really small change above your’s original pull request allowing not to convert strings representing floats to floats. As for me, I’m doing this because I need to fetch some float values and put them is a string making sure the representation of the values didn’t change, which is critical.

Is it possible you merge this in your’s pull request?

Kind regards,
Alexey